### PR TITLE
Pins cake.incubator version

### DIFF
--- a/.cake/Configuration.cake
+++ b/.cake/Configuration.cake
@@ -1,4 +1,4 @@
-#addin "Cake.Incubator"
+#addin "Cake.Incubator&version=3.1.0"
 #load "Configuration-Version.cake"
 
 const string _solutionFilePathPattern = "*.sln";


### PR DESCRIPTION
Cake.Incubator was updated to v4 and cake-mix wasnt pinning its version....until now.

Bad me!