### PR TITLE
Remove verbosity settings from .Net Core publish tasks

### DIFF
--- a/.cake/Publish-Pack-DotNetCore.cake
+++ b/.cake/Publish-Pack-DotNetCore.cake
@@ -12,8 +12,7 @@ Task("Publish:Pack:DotNetCore")
         NoRestore = true,
         IncludeSymbols = true,
         Configuration = config.Solution.BuildConfiguration,
-        OutputDirectory = projectArtifactDirectory,
-        Verbosity = DotNetCoreVerbosity.Minimal
+        OutputDirectory = projectArtifactDirectory
     };
     settings.MSBuildSettings = new DotNetCoreMSBuildSettings();
     settings.MSBuildSettings

--- a/.cake/Publish-Zip-DotNetCore.cake
+++ b/.cake/Publish-Zip-DotNetCore.cake
@@ -18,8 +18,7 @@ Task("Publish:Zip:DotNetCore")
         {
             NoRestore = true,
             Configuration = config.Solution.BuildConfiguration,
-            OutputDirectory = publishDirectory,
-            Verbosity = DotNetCoreVerbosity.Minimal,
+            OutputDirectory = publishDirectory
         };
 
         settings.MSBuildSettings = new DotNetCoreMSBuildSettings();


### PR DESCRIPTION
Regarding the issue with Verbosity being made obsolete in Cake - remove the verbosity setting from .Net publish tasks to prevent failing builds.

See this issue: https://github.com/cake-build/cake/issues/2543