### PR TITLE
Add missing testAssembly declaration to xUnit2 task

### DIFF
--- a/.cake/Test-XUnit2.cake
+++ b/.cake/Test-XUnit2.cake
@@ -14,6 +14,8 @@ Task("Test:XUnit2")
         var assemblyName = config.Solution.GetProjectName(testProject);
         var testResultsRoot = $"{config.Artifacts.Root}/test-results";
         var testResultsXml = $"{testResultsRoot}/{assemblyName}.xml";
+        var testAssembly = $"{testProject.OutputPaths.FirstOrDefault().ToString()}/{assemblyName}.dll";
+
         try 
         {
             var settings = new XUnit2Settings {


### PR DESCRIPTION
The xUnit2 task does not declare the testAssembly variable used later on, causing the task to fail.