### PR TITLE
Remove UseToolVersion VS2017 from MsBuild task

### DIFF
--- a/.cake/Build-MsBuild.cake
+++ b/.cake/Build-MsBuild.cake
@@ -8,7 +8,6 @@ Task("Build:MsBuild")
     MSBuild(config.Solution.Path.ToString(), c => c
         .SetConfiguration(config.Solution.BuildConfiguration)
         .SetVerbosity(Verbosity.Minimal)
-        .UseToolVersion(MSBuildToolVersion.VS2017)
         .WithWarningsAsError()
         .WithTarget("Build")
     );

--- a/.cake/Build-MsBuild.cake
+++ b/.cake/Build-MsBuild.cake
@@ -1,5 +1,26 @@
 #load "Configuration.cake"
 
+public partial class Configuration {
+    public MSBuildToolVersion MSBuildToolVersion { get; private set; } = MSBuildToolVersion.Default;
+
+    public Configuration SetMSBuildToolVersion(MSBuildToolVersion toolVersion, bool allowArgumentOverride = true){
+
+        var argument = ParseEnum<MSBuildToolVersion>(context.Argument("MSBuildToolVersion", "Default"));
+        if(allowArgumentOverride && argument != MSBuildToolVersion.Default){
+            MSBuildToolVersion = argument;
+            return this;
+        }
+
+        MSBuildToolVersion = toolVersion;
+        return this;
+    }
+
+    private static T ParseEnum<T>(string value)
+    {
+        return (T) Enum.Parse(typeof(T), value, true);
+    }
+}
+
 Task("Build:MsBuild")
     .IsDependentOn("Restore")
     .IsDependeeOf("Build")

--- a/.cake/Build-MsBuild.cake
+++ b/.cake/Build-MsBuild.cake
@@ -1,37 +1,17 @@
 #load "Configuration.cake"
-
-public partial class Configuration {
-    public MSBuildToolVersion MSBuildToolVersion { get; private set; } = MSBuildToolVersion.Default;
-
-    public Configuration SetMSBuildToolVersion(MSBuildToolVersion toolVersion, bool allowArgumentOverride = true){
-
-        var argument = ParseEnum<MSBuildToolVersion>(context.Argument("MSBuildToolVersion", "Default"));
-        if(allowArgumentOverride && argument != MSBuildToolVersion.Default){
-            MSBuildToolVersion = argument;
-            return this;
-        }
-
-        MSBuildToolVersion = toolVersion;
-        return this;
-    }
-
-    private static T ParseEnum<T>(string value)
-    {
-        return (T) Enum.Parse(typeof(T), value, true);
-    }
-}
+#load "Configuration-MsBuild.cake"
 
 Task("Build:MsBuild")
     .IsDependentOn("Restore")
     .IsDependeeOf("Build")
     .Does<Configuration>(config =>
 {
-    Information("MS Build Tool Version: " + config.MsBuildToolVersion.ToString());
+    Information("MS Build Tool Version: " + config.MSBuildToolVersion.ToString());
 
     MSBuild(config.Solution.Path.ToString(), c => c
         .SetConfiguration(config.Solution.BuildConfiguration)
         .SetVerbosity(Verbosity.Minimal)
-        .UseToolVersion(config.MsBuildToolVersion)
+        .UseToolVersion(config.MSBuildToolVersion)
         .WithWarningsAsError()
         .WithTarget("Build")
     );

--- a/.cake/Build-MsBuild.cake
+++ b/.cake/Build-MsBuild.cake
@@ -6,12 +6,14 @@ Task("Build:MsBuild")
     .IsDependeeOf("Build")
     .Does<Configuration>(config =>
 {
-    Information("MS Build Tool Version: " + config.MSBuildToolVersion.ToString());
+    var toolVersion = config.GetTaskParameter<MSBuildToolVersion>("MsBuild:Version", MSBuildToolVersion.Default);
+
+    Information("MS Build Tool Version: " + toolVersion.ToString());
 
     MSBuild(config.Solution.Path.ToString(), c => c
         .SetConfiguration(config.Solution.BuildConfiguration)
         .SetVerbosity(Verbosity.Minimal)
-        .UseToolVersion(config.MSBuildToolVersion)
+        .UseToolVersion(toolVersion)
         .WithWarningsAsError()
         .WithTarget("Build")
     );

--- a/.cake/Build-MsBuild.cake
+++ b/.cake/Build-MsBuild.cake
@@ -5,9 +5,12 @@ Task("Build:MsBuild")
     .IsDependeeOf("Build")
     .Does<Configuration>(config =>
 {
+    Information("MS Build Tool Version: " + config.MsBuildToolVersion.ToString());
+
     MSBuild(config.Solution.Path.ToString(), c => c
         .SetConfiguration(config.Solution.BuildConfiguration)
         .SetVerbosity(Verbosity.Minimal)
+        .UseToolVersion(config.MsBuildToolVersion)
         .WithWarningsAsError()
         .WithTarget("Build")
     );

--- a/.cake/Configuration-MsBuild.cake
+++ b/.cake/Configuration-MsBuild.cake
@@ -1,0 +1,22 @@
+#load "Configuration.cake"
+
+public partial class Configuration {
+    public MSBuildToolVersion MSBuildToolVersion { get; private set; } = MSBuildToolVersion.Default;
+
+    public Configuration SetMSBuildToolVersion(MSBuildToolVersion toolVersion, bool allowArgumentOverride = true){
+
+        var argument = ParseEnum<MSBuildToolVersion>(context.Argument("MSBuildToolVersion", "Default"));
+        if(allowArgumentOverride && argument != MSBuildToolVersion.Default){
+            MSBuildToolVersion = argument;
+            return this;
+        }
+
+        MSBuildToolVersion = toolVersion;
+        return this;
+    }
+
+    private static T ParseEnum<T>(string value)
+    {
+        return (T) Enum.Parse(typeof(T), value, true);
+    }
+}

--- a/.cake/Configuration-MsBuild.cake
+++ b/.cake/Configuration-MsBuild.cake
@@ -1,17 +1,14 @@
 #load "Configuration.cake"
-
 public partial class Configuration {
-    public MSBuildToolVersion MSBuildToolVersion { get; private set; } = MSBuildToolVersion.Default;
 
-    public Configuration SetMSBuildToolVersion(MSBuildToolVersion toolVersion, bool allowArgumentOverride = true){
-
+    public Configuration SetMSBuildToolVersion(MSBuildToolVersion toolVersion, bool allowArgumentOverride = true)
+    {
         var argument = ParseEnum<MSBuildToolVersion>(context.Argument("MSBuildToolVersion", "Default"));
-        if(allowArgumentOverride && argument != MSBuildToolVersion.Default){
-            MSBuildToolVersion = argument;
-            return this;
-        }
 
-        MSBuildToolVersion = toolVersion;
+        var version = (allowArgumentOverride && argument != MSBuildToolVersion.Default) ? argument : toolVersion;
+
+        this.TaskParameters.Add("MsBuild:Version", version);
+
         return this;
     }
 

--- a/.cake/Configuration.cake
+++ b/.cake/Configuration.cake
@@ -60,8 +60,6 @@ public partial class Configuration {
 
     public BuildVersion Version { get; }
 
-    public MSBuildToolVersion MsBuildToolVersion { get; }
-
     public SolutionParameters Solution { get; }
 
     public ArtifactsParameters Artifacts { get; }
@@ -83,8 +81,6 @@ public partial class Configuration {
         Version = BuildVersion.DetermineBuildVersion(context);
         
         Artifacts = new ArtifactsParameters(context, artifactsRootPath ?? context.Directory("artifacts"));
-
-        MsBuildToolVersion = ParseEnum<MSBuildToolVersion>(context.Argument("MsBuildToolVersion", "Default"));
     }
 
     public ICakeLog Logger => context.Log;
@@ -93,12 +89,6 @@ public partial class Configuration {
     {
         Solution.Log(logger);
     }
-
-    private static T ParseEnum<T>(string value)
-    {
-        return (T) Enum.Parse(typeof(T), value, true);
-    }
-
 }
 public enum ArtifactTypeOption {
     Zip,

--- a/.cake/Configuration.cake
+++ b/.cake/Configuration.cake
@@ -60,6 +60,8 @@ public partial class Configuration {
 
     public BuildVersion Version { get; }
 
+    public MSBuildToolVersion MsBuildToolVersion { get; }
+
     public SolutionParameters Solution { get; }
 
     public ArtifactsParameters Artifacts { get; }
@@ -81,6 +83,8 @@ public partial class Configuration {
         Version = BuildVersion.DetermineBuildVersion(context);
         
         Artifacts = new ArtifactsParameters(context, artifactsRootPath ?? context.Directory("artifacts"));
+
+        MsBuildToolVersion = ParseEnum<MSBuildToolVersion>(context.Argument("MsBuildToolVersion", "Default"));
     }
 
     public ICakeLog Logger => context.Log;
@@ -88,6 +92,11 @@ public partial class Configuration {
     public void Log(ICakeLog logger) 
     {
         Solution.Log(logger);
+    }
+
+    private static T ParseEnum<T>(string value)
+    {
+        return (T) Enum.Parse(typeof(T), value, true);
     }
 
 }

--- a/.cake/Configuration.cake
+++ b/.cake/Configuration.cake
@@ -89,6 +89,16 @@ public partial class Configuration {
     {
         Solution.Log(logger);
     }
+
+    public T GetTaskParameter<T>(string key, T defaultValue){
+
+        if(TaskParameters.TryGetValue(key, out object value) && value is T)
+        {
+            return (T)value;
+        } 
+
+        return defaultValue;     
+    }
 }
 public enum ArtifactTypeOption {
     Zip,

--- a/.cake/Publish-MsBuild-Folder.cake
+++ b/.cake/Publish-MsBuild-Folder.cake
@@ -5,6 +5,8 @@ Task("Publish:MsBuild")
     .IsDependeeOf("Publish")
     .Does<Configuration>(config => 
 {
+    Information("MsBuild Tool Version: " + config.MsBuildToolVersion.ToString());
+
     foreach(var webProject in config.Solution.WebProjects) {
         var assemblyName = config.Solution.GetProjectName(webProject);
         var projectArtifactDirectory = $"{config.Artifacts.GetRootFor(ArtifactTypeOption.Zip)}/{assemblyName}";
@@ -14,7 +16,7 @@ Task("Publish:MsBuild")
         MSBuild(webProject.ProjectFilePath, c => c
             .SetConfiguration(config.Solution.BuildConfiguration)
             .SetVerbosity(Verbosity.Quiet)
-            .UseToolVersion(MSBuildToolVersion.VS2017)
+            .UseToolVersion(config.MsBuildToolVersion)
             .WithWarningsAsError()
             .WithTarget("Package")
             .WithProperty("DeployTarget", "PipelinePreDeployCopyAllFilesToOneFolder")

--- a/.cake/Publish-MsBuild-Folder.cake
+++ b/.cake/Publish-MsBuild-Folder.cake
@@ -6,7 +6,9 @@ Task("Publish:MsBuild")
     .IsDependeeOf("Publish")
     .Does<Configuration>(config => 
 {
-    Information("MsBuild Tool Version: " + config.MSBuildToolVersion.ToString());
+    var toolVersion = config.GetTaskParameter<MSBuildToolVersion>("MsBuild:Version", MSBuildToolVersion.Default);
+
+    Information("MsBuild Tool Version: " + toolVersion.ToString());
 
     foreach(var webProject in config.Solution.WebProjects) {
         var assemblyName = config.Solution.GetProjectName(webProject);
@@ -17,7 +19,7 @@ Task("Publish:MsBuild")
         MSBuild(webProject.ProjectFilePath, c => c
             .SetConfiguration(config.Solution.BuildConfiguration)
             .SetVerbosity(Verbosity.Quiet)
-            .UseToolVersion(config.MSBuildToolVersion)
+            .UseToolVersion(toolVersion)
             .WithWarningsAsError()
             .WithTarget("Package")
             .WithProperty("DeployTarget", "PipelinePreDeployCopyAllFilesToOneFolder")

--- a/.cake/Publish-MsBuild-Folder.cake
+++ b/.cake/Publish-MsBuild-Folder.cake
@@ -1,11 +1,12 @@
 #load "Configuration.cake"
+#load "Configuration-MsBuild.cake"
 
 Task("Publish:MsBuild")
     .IsDependentOn("Build")
     .IsDependeeOf("Publish")
     .Does<Configuration>(config => 
 {
-    Information("MsBuild Tool Version: " + config.MsBuildToolVersion.ToString());
+    Information("MsBuild Tool Version: " + config.MSBuildToolVersion.ToString());
 
     foreach(var webProject in config.Solution.WebProjects) {
         var assemblyName = config.Solution.GetProjectName(webProject);
@@ -16,7 +17,7 @@ Task("Publish:MsBuild")
         MSBuild(webProject.ProjectFilePath, c => c
             .SetConfiguration(config.Solution.BuildConfiguration)
             .SetVerbosity(Verbosity.Quiet)
-            .UseToolVersion(config.MsBuildToolVersion)
+            .UseToolVersion(config.MSBuildToolVersion)
             .WithWarningsAsError()
             .WithTarget("Package")
             .WithProperty("DeployTarget", "PipelinePreDeployCopyAllFilesToOneFolder")

--- a/.cake/Publish-MsBuild-WebDeploy.cake
+++ b/.cake/Publish-MsBuild-WebDeploy.cake
@@ -6,7 +6,9 @@ Task("Publish:MsBuild")
     .IsDependeeOf("Publish")
     .Does<Configuration>(config => 
 {
-    Information("MsBuild Tool Version: " + config.MSBuildToolVersion.ToString());
+    var toolVersion = config.GetTaskParameter<MSBuildToolVersion>("MsBuild:Version", MSBuildToolVersion.Default);
+
+    Information("MsBuild Tool Version: " + toolVersion.ToString());
 
     foreach(var webProject in config.Solution.WebProjects) {
         var assemblyName = config.Solution.GetProjectName(webProject);
@@ -17,7 +19,7 @@ Task("Publish:MsBuild")
         MSBuild(webProject.ProjectFilePath, c => c
             .SetConfiguration(config.Solution.BuildConfiguration)
             .SetVerbosity(Verbosity.Quiet)
-            .UseToolVersion(config.MSBuildToolVersion)
+            .UseToolVersion(toolVersion)
             .WithWarningsAsError()
             .WithTarget("Package")
             .WithProperty("PackageAsSingleFile", "true")

--- a/.cake/Publish-MsBuild-WebDeploy.cake
+++ b/.cake/Publish-MsBuild-WebDeploy.cake
@@ -1,11 +1,12 @@
 #load "Configuration.cake"
+#load "Configuration-MsBuild.cake"
 
 Task("Publish:MsBuild")
     .IsDependentOn("Build")
     .IsDependeeOf("Publish")
     .Does<Configuration>(config => 
 {
-    Information("MsBuild Tool Version: " + config.MsBuildToolVersion.ToString());
+    Information("MsBuild Tool Version: " + config.MSBuildToolVersion.ToString());
 
     foreach(var webProject in config.Solution.WebProjects) {
         var assemblyName = config.Solution.GetProjectName(webProject);
@@ -16,7 +17,7 @@ Task("Publish:MsBuild")
         MSBuild(webProject.ProjectFilePath, c => c
             .SetConfiguration(config.Solution.BuildConfiguration)
             .SetVerbosity(Verbosity.Quiet)
-            .UseToolVersion(config.MsBuildToolVersion)
+            .UseToolVersion(config.MSBuildToolVersion)
             .WithWarningsAsError()
             .WithTarget("Package")
             .WithProperty("PackageAsSingleFile", "true")

--- a/.cake/Publish-MsBuild-WebDeploy.cake
+++ b/.cake/Publish-MsBuild-WebDeploy.cake
@@ -5,6 +5,8 @@ Task("Publish:MsBuild")
     .IsDependeeOf("Publish")
     .Does<Configuration>(config => 
 {
+    Information("MsBuild Tool Version: " + config.MsBuildToolVersion.ToString());
+
     foreach(var webProject in config.Solution.WebProjects) {
         var assemblyName = config.Solution.GetProjectName(webProject);
         var projectArtifactDirectory = $"{config.Artifacts.GetRootFor(ArtifactTypeOption.WebDeploy)}/{assemblyName}";
@@ -14,7 +16,7 @@ Task("Publish:MsBuild")
         MSBuild(webProject.ProjectFilePath, c => c
             .SetConfiguration(config.Solution.BuildConfiguration)
             .SetVerbosity(Verbosity.Quiet)
-            .UseToolVersion(MSBuildToolVersion.VS2017)
+            .UseToolVersion(config.MsBuildToolVersion)
             .WithWarningsAsError()
             .WithTarget("Package")
             .WithProperty("PackageAsSingleFile", "true")


### PR DESCRIPTION
This causes the task to fail if VS 2017 isn't installed.