### PR TITLE
Fix an issue where the Test-XUnit2 task had TFTestRunnerType set to VSTest

### DIFF
--- a/.cake/Test-XUnit2.cake
+++ b/.cake/Test-XUnit2.cake
@@ -42,7 +42,7 @@ Task("Test:XUnit2")
                 Configuration = config.Solution.BuildConfiguration,
                 MergeTestResults = true,
                 TestResultsFiles = testResults,
-                TestRunner = TFTestRunnerType.VSTest
+                TestRunner = TFTestRunnerType.XUnit
             });    
         }
     }


### PR DESCRIPTION
Changed to use TFTestRunnerType.XUnit instead.