### PR TITLE
Update cake.npm reference to 0.17

### DIFF
--- a/.cake/Npm-RunScript.cake
+++ b/.cake/Npm-RunScript.cake
@@ -1,4 +1,4 @@
-#addin "nuget:?package=Cake.Npm&version=0.15.0"
+#addin "nuget:?package=Cake.Npm&version=0.17.0"
 
 public partial class Configuration 
 {


### PR DESCRIPTION
Fix warning in builds:

`The assembly 'Cake.Npm, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'
is referencing an older version of Cake.Core (0.28.0).
For best compatibility it should target Cake.Core version 0.33.0.`