### PR TITLE
Allow nuget download if it does not exist

### DIFF
--- a/.cake/Restore-NuGet.cake
+++ b/.cake/Restore-NuGet.cake
@@ -1,3 +1,5 @@
+#tool nuget:?package=NuGet.CommandLine&version=6.1.0
+
 #load "Configuration.cake"
 
 Task("Restore:NuGet")


### PR DESCRIPTION
When using the recommended dotnet core runner, the command line nuget tool is required for legacy projects